### PR TITLE
Optimize scanning process and fix first Tab Index error

### DIFF
--- a/src/utils/navigation.py
+++ b/src/utils/navigation.py
@@ -72,6 +72,16 @@ class Navigation:
         self.gamepad.release_button(button=vg.XUSB_BUTTON.XUSB_GAMEPAD_RIGHT_SHOULDER)
         self.gamepad.update()
         time.sleep(self.NAV_TIME)  # to wait for the tab to load
+        
+    def change_tab_prev(self) -> None:
+        if self.gamepad is None:
+            raise ValueError('GamepadNotInitialized')
+        self.gamepad.press_button(button=vg.XUSB_BUTTON.XUSB_GAMEPAD_LEFT_SHOULDER)
+        self.gamepad.update()
+        time.sleep(self.PRESSED_FOR)
+        self.gamepad.release_button(button=vg.XUSB_BUTTON.XUSB_GAMEPAD_LEFT_SHOULDER)
+        self.gamepad.update()
+        time.sleep(self.NAV_TIME)  # to wait for the tab to load
 
     def get_aspect_ratio(self) -> str:
         """Get the aspect ratio of the game window


### PR DESCRIPTION
- now it's going down 4 rows and scanning all 5 rows (going down 4 to make sure it doesn`t miss any).

- switching tabs right and left at first start to reset chive index to the first index row.