### PR TITLE
update wake_up call to reset the index cursor

### DIFF
--- a/src/utils/navigation.py
+++ b/src/utils/navigation.py
@@ -46,11 +46,9 @@ class Navigation:
         win32gui.SetForegroundWindow(self._hwnd)
 
     def wake_up(self) -> None:
-        self.gamepad.press_button(button=vg.XUSB_BUTTON.XUSB_GAMEPAD_DPAD_UP)
-        self.gamepad.update()
+        self.change_tab()
         time.sleep(self.WAKE_WAIT)
-        self.gamepad.release_button(button=vg.XUSB_BUTTON.XUSB_GAMEPAD_DPAD_UP)
-        self.gamepad.update()
+        self.change_tab_prev()
         time.sleep(self.WAKE_WAIT)
 
     def go_down(self) -> None:
@@ -70,6 +68,16 @@ class Navigation:
         self.gamepad.update()
         time.sleep(self.PRESSED_FOR)
         self.gamepad.release_button(button=vg.XUSB_BUTTON.XUSB_GAMEPAD_RIGHT_SHOULDER)
+        self.gamepad.update()
+        time.sleep(self.NAV_TIME)  # to wait for the tab to load
+        
+    def change_tab_prev(self) -> None:
+        if self.gamepad is None:
+            raise ValueError('GamepadNotInitialized')
+        self.gamepad.press_button(button=vg.XUSB_BUTTON.XUSB_GAMEPAD_LEFT_SHOULDER)
+        self.gamepad.update()
+        time.sleep(self.PRESSED_FOR)
+        self.gamepad.release_button(button=vg.XUSB_BUTTON.XUSB_GAMEPAD_LEFT_SHOULDER)
         self.gamepad.update()
         time.sleep(self.NAV_TIME)  # to wait for the tab to load
 


### PR DESCRIPTION
if user controller cursor is above **4th ROW** of the first tab it will work normally end up getting **22/22 achieve**.

if user controller cursor is below **5th ROW** of the first tab it will skip all the above row end up getting **21/22 achieve or less**. (this happen if user manually control using controller to go down or the program is scanning but cancel mid-way AND using mouse & keyboard to scroll back at top, it won`t reset the controller cursor index back to TOP)

my current solution is to switch tabs to reset the cursor index back to TOP.